### PR TITLE
Update support for Galaxy ISA data type

### DIFF
--- a/galaxy/isa_get_study.xml
+++ b/galaxy/isa_get_study.xml
@@ -2,31 +2,32 @@
 <tool id="isa_get_study" name="Get an ISA study" version="1.0">
     <description>Get an ISA dataset from MetaboLights</description>
     <command><![CDATA[
-        run_mtblisa.py get-study "${mtbls_id}" "${output.extra_files_path}" --isa-format ${isa_format} 
+        run_mtblisa.py get-study "${mtbls_id}" "${output.extra_files_path}" --isa-format ${isa_format}
     ]]></command>
     <inputs>
         <param name="mtbls_id" type="text" label="Metabolights Study Identifier"/>
+        <!--
         <param name="output_format" type="select" label="Output ISA type">
           <option value="isa-tab" selected="true">ISA-TAB</option>
           <option value="isa-json">ISA-JSON</option>
         </param>
+        -->
     </inputs>
     <outputs>
         <!-- default output format:  isa-tab.  When selector list `isa_format` is set to
              isa-json the output format is changed to `isa-json`. -->
-				<!--<data name="output" format="isa-tab">
-            <change_format>
-                <when input="isa_format" value="isa-json" format="isa-json" />
-            </change_format>
-				</data>-->
-
-        <data name="output_test_tab" format="isa-tab">
-          <filter>output_format == "isa-tab"</filter>
+        <!-- Until after the cerebellin release we're only going to support isa-tab
+        <data name="output" format="isa-tab">
+          <change_format>
+              <when input="isa_format" value="isa-json" format="isa-json" />
+          </change_format>
         </data>
+
         <data name="output_test_json" format="isa-json">
           <filter>output_format == "isa-json"</filter>
         </data>
-
+        -->
+        <data name="output_test_tab" format="isa-tab" />
     </outputs>
     <stdio>
       <exit_code range="1:" level="fatal"/>

--- a/galaxy/isa_get_study.xml
+++ b/galaxy/isa_get_study.xml
@@ -6,13 +6,27 @@
     ]]></command>
     <inputs>
         <param name="mtbls_id" type="text" label="Metabolights Study Identifier"/>
-        <param name="isa_format" type="select" label="ISA type">
+        <param name="output_format" type="select" label="Output ISA type">
           <option value="isa-tab" selected="true">ISA-TAB</option>
           <option value="isa-json">ISA-JSON</option>
         </param>
     </inputs>
     <outputs>
-        <data format="isa" name="output"/>
+        <!-- default output format:  isa-tab.  When selector list `isa_format` is set to
+             isa-json the output format is changed to `isa-json`. -->
+				<!--<data name="output" format="isa-tab">
+            <change_format>
+                <when input="isa_format" value="isa-json" format="isa-json" />
+            </change_format>
+				</data>-->
+
+        <data name="output_test_tab" format="isa-tab">
+          <filter>output_format == "isa-tab"</filter>
+        </data>
+        <data name="output_test_json" format="isa-json">
+          <filter>output_format == "isa-json"</filter>
+        </data>
+
     </outputs>
     <stdio>
       <exit_code range="1:" level="fatal"/>


### PR DESCRIPTION
This PR updates galaxy wrappers to support the `isa-tab` Galaxy data type.  Concretely, this only affects the `get-study` tool, which outputs unarchived ISA data.  This PR only supports `isa-tab`; `isa-json` output won't be provided for this PhenoMeNal release.